### PR TITLE
Change public SAML page routes

### DIFF
--- a/samlauth.inc
+++ b/samlauth.inc
@@ -28,7 +28,7 @@ function samlauth_clean_string($string) {
  *   A formatted URL representing the SP Entity ID.
  */
 function samlauth_entity_id($idp_machine_name) {
-  return url('samlauth/' . $idp_machine_name, ['absolute' => TRUE]);
+  return url('saml/' . $idp_machine_name, ['absolute' => TRUE]);
 }
 
 /**
@@ -375,7 +375,7 @@ function samlauth_subject_name_id_map() {
  * @return string
  */
 function samlauth_url_acs($idp_machine_name) {
-  return url('samlauth/' . $idp_machine_name . '/consume', [
+  return url('saml/' . $idp_machine_name . '/consume', [
     'absolute' => TRUE,
   ]);
 }
@@ -388,7 +388,7 @@ function samlauth_url_acs($idp_machine_name) {
  * @return string
  */
 function samlauth_url_metadata($idp_machine_name) {
-  return url('samlauth/' . $idp_machine_name . '/metadata.xml', [
+  return url('saml/' . $idp_machine_name . '/metadata.xml', [
     'absolute' => TRUE,
   ]);
 }

--- a/samlauth.module
+++ b/samlauth.module
@@ -21,7 +21,7 @@ function samlauth_menu() {
       'file' => 'samlauth.admin.inc',
       'type' => MENU_NORMAL_ITEM,
     ],
-    'samlauth/%samlauth/consume' => [
+    'saml/%samlauth/consume' => [
       'title' => 'SAML Assertion Customer Service',
       'description' => 'The endpoint to process the SAML response.',
       'page callback' => 'samlauth_page_acs',
@@ -30,7 +30,7 @@ function samlauth_menu() {
       'file' => 'samlauth.pages.inc',
       'type' => MENU_CALLBACK,
     ],
-    'samlauth/%samlauth/login' => [
+    'saml/%samlauth/login' => [
       'title' => 'SAML Login',
       'description' => 'Sends an AuthnRequest to the Identity Provider.',
       'page callback' => 'samlauth_page_login',
@@ -40,7 +40,7 @@ function samlauth_menu() {
       'file' => 'samlauth.pages.inc',
       'type' => MENU_CALLBACK,
     ],
-    'samlauth/%samlauth/metadata.xml' => [
+    'saml/%samlauth/metadata.xml' => [
       'title' => 'SAML Metadata',
       'description' => 'The metadata for the Service Provider.',
       'page callback' => 'samlauth_page_metadata',

--- a/samlauth.pages.inc
+++ b/samlauth.pages.inc
@@ -7,7 +7,7 @@
 
 /**
  * Callback: samlauth_menu().
- * Route: samlauth/%samlauth/consume
+ * Route: saml/%samlauth/consume
  *
  * The Assertion Consumer Service to process the SAML Response from the
  * Identity Provider. Users are redirected from this page.
@@ -53,7 +53,7 @@ function samlauth_page_acs($idp_machine_name) {
 
 /**
  * Callback: samlauth_menu().
- * Route: samlauth/%samlauth/login
+ * Route: saml/%samlauth/login
  *
  * This page initiates an AuthnRequest to the Identity Provider. All users are
  * redirected from this page.
@@ -75,7 +75,7 @@ function samlauth_page_login($idp_machine_name) {
 
 /**
  * Callback: samlauth_menu().
- * Route: samlauth/%samlauth/metadata.xml
+ * Route: saml/%samlauth/metadata.xml
  *
  * This page outputs the Service Provider metadata in XML.
  *


### PR DESCRIPTION
I'm changing the paths of the SAML pages to match the routes defined in the D8 module so all 3 BCBSA sites have SSO residing in the same base path.

BLUEALLY-466