### PR TITLE
Add support for global settings

### DIFF
--- a/samlauth.inc
+++ b/samlauth.inc
@@ -251,6 +251,17 @@ function samlauth_login_register($name_id, $idp_machine_name, array $saml_attrib
  * @return array
  */
 function samlauth_settings($idp_machine_name) {
+  // Gather settings set in settings.php
+  $settings = !empty($GLOBALS['conf']['samlauth'])
+    ? $GLOBALS['conf']['samlauth']
+    : NULL;
+
+  // If there are global settings and the IdP machine name is in the global
+  // settings then merge the settings with the default settings array.
+  if ($settings && array_key_exists($idp_machine_name, $settings)) {
+    return samlauth_settings_merge($settings[$idp_machine_name]);
+  }
+
   $result = db_select('samlauth_settings')
     ->fields('samlauth_settings')
     ->condition('idp_machine_name', $idp_machine_name)

--- a/samlauth.module
+++ b/samlauth.module
@@ -73,11 +73,9 @@ function samlauth_permission() {
  * @return string|false
  */
 function samlauth_load($idp_machine_name) {
-  $idp_exists = db_select('samlauth_settings')
-    ->fields('samlauth_settings')
-    ->condition('idp_machine_name', $idp_machine_name)
-    ->execute()
-    ->fetchField();
+  module_load_include('inc', 'samlauth', 'samlauth');
+
+  $idp_exists = !empty(samlauth_settings($idp_machine_name));
 
   if (!$idp_exists) {
     return FALSE;


### PR DESCRIPTION
This adds support for global settings for the samlauth module in settings.php. SAML Identity Providers can now be defined in settings.php. This is useful for Blue365 as there's 5 different environments we need to configure SSO for. Any Identity Providers defined in settings.php will not be configurable through the UI.

Example:
```php
$conf['samlauth']['default'] = [
  'idp_machine_name' => 'default',
  'idp_public_key' => '...',
  'idp_private_key' => '...',
  ...
];
```