### PR TITLE
Add support for RelayState

### DIFF
--- a/samlauth.inc
+++ b/samlauth.inc
@@ -32,6 +32,39 @@ function samlauth_entity_id($idp_machine_name) {
 }
 
 /**
+ * Get the RelayState from the query string.
+ *
+ * @return string|NULL
+ *   The RelayState path if the destination passed validation, or NULL if the
+ *   RelayState is not given or if the destination path is malformed.
+ */
+function samlauth_get_relay_state() {
+  if (!isset($_GET['RelayState'])) {
+    return NULL;
+  }
+
+  $relay_state = parse_url($_GET['RelayState']);
+
+  // parse_url() may return FALSE for a malformed URL, if so return NULL before
+  // we start building our result.
+  if (!$relay_state || empty($relay_state['path'])) {
+    return NULL;
+  }
+
+  $result = $relay_state['path'];
+
+  if (isset($relay_state['query'])) {
+    $result .= '?' . $relay_state['query'];
+  }
+
+  if (isset($relay_state['fragment'])) {
+    $result .= '#' . $relay_state['fragment'];
+  }
+
+  return $result;
+}
+
+/**
  * A procedural multiton holding the OneLogin_Saml2_Auth instance.
  *
  * @param string $idp_machine_name

--- a/samlauth.pages.inc
+++ b/samlauth.pages.inc
@@ -15,12 +15,14 @@
  * @param string $idp_machine_name
  */
 function samlauth_page_acs($idp_machine_name) {
+  module_load_include('inc', 'samlauth', 'samlauth');
+
   // If the user is logged in already then redirect them away from this page.
   if (user_is_logged_in()) {
-    drupal_goto('<front>');
-  }
+    $destination = samlauth_get_relay_state() ?: '<front>';
 
-  module_load_include('inc', 'samlauth', 'samlauth');
+    drupal_goto($destination);
+  }
 
   $auth = samlauth_instance($idp_machine_name);
 
@@ -48,7 +50,9 @@ function samlauth_page_acs($idp_machine_name) {
     drupal_set_message(t('There was an error processing your request.'), 'error');
   }
 
-  drupal_goto('<front>');
+  $destination = samlauth_get_relay_state() ?: '<front>';
+
+  drupal_goto($destination);
 }
 
 /**


### PR DESCRIPTION
This adds support for the `RelayState` parameter to be passed in the query string. This is used on Blue365 for plans to "deep link" to deals. 