### PR TITLE
Add new hooks

### DIFF
--- a/samlauth.inc
+++ b/samlauth.inc
@@ -317,7 +317,7 @@ function samlauth_settings($idp_machine_name) {
  * @return array
  */
 function samlauth_settings_onelogin_format(array $settings) {
-  return [
+  $settings = [
     'strict' => TRUE,
     'sp' => [
       'entityId' => samlauth_entity_id($settings['idp_machine_name']),
@@ -346,6 +346,10 @@ function samlauth_settings_onelogin_format(array $settings) {
       'digestAlgorithm' => 'http://www.w3.org/2001/04/xmlenc#sha256',
     ],
   ];
+
+  drupal_alter('samlauth_settings', $settings);
+
+  return $settings;
 }
 
 /**

--- a/samlauth.pages.inc
+++ b/samlauth.pages.inc
@@ -48,6 +48,16 @@ function samlauth_page_acs($idp_machine_name) {
   catch (Exception $e) {
     watchdog('samlauth', $e->getMessage(), [], WATCHDOG_ERROR);
     drupal_set_message(t('There was an error processing your request.'), 'error');
+
+    $redirect_locations = module_invoke_all('samlauth_error_redirect_url');
+
+    if (!empty($redirect_locations)) {
+      // Only get the first redirect location that is found. All others will
+      // be ignored.
+      $redirect_location = reset($redirect_locations);
+
+      drupal_goto($redirect_location);
+    }
   }
 
   $destination = samlauth_get_relay_state() ?: '<front>';


### PR DESCRIPTION
This PR adds new hooks that allows users to alter the onelogin samlauth settings and to implement a redirection to an error page on a failed SAML assertion.